### PR TITLE
Use GitHub as the source of documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <version>1.4.3-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Delivery Pipeline Plugin</name>
-    <url>https://plugins.jenkins.io/delivery-pipeline-plugin/</url>
+    <url>https://github.com/jenkinsci/delivery-pipeline-plugin</url>
 
     <licenses>
         <license>


### PR DESCRIPTION
The URL field should point either to GH or wiki, because that's what the plugin site uses as source.
This current URL was introduced in https://github.com/jenkinsci/delivery-pipeline-plugin/commit/28bccea096189177f75546aeafca8856d17f0829 .
Someone more familiar with this plugin might want to review the differences between the GH readme and https://raw.githubusercontent.com/jenkins-infra/plugins-wiki-docs/master/delivery-pipeline-plugin/README.md and migrate some content in a follow-up PR.