### PR TITLE
Remove `framework.prototype.prototype` adjunct - Throws file not found error

### DIFF
--- a/src/main/resources/se/diabol/jenkins/pipeline/DeliveryPipelineView/index.jelly
+++ b/src/main/resources/se/diabol/jenkins/pipeline/DeliveryPipelineView/index.jelly
@@ -21,8 +21,6 @@
                     <script src="${resURL}/scripts/behavior.js" type="text/javascript"/>
 
                     <!-- we include our own prototype.js, so don't let stapler pull in another. -->
-                    <st:adjunct assumes="org.kohsuke.stapler.framework.prototype.prototype"
-                                includes="org.kohsuke.stapler.bind"/>
 
                     <script src="${resURL}/scripts/hudson-behavior.js" type="text/javascript"></script>
                     <script src="${resURL}/scripts/sortable.js" type="text/javascript"/>

--- a/src/main/resources/se/diabol/jenkins/workflow/WorkflowPipelineView/index.jelly
+++ b/src/main/resources/se/diabol/jenkins/workflow/WorkflowPipelineView/index.jelly
@@ -21,8 +21,6 @@
                     <script src="${resURL}/scripts/behavior.js" type="text/javascript"/>
 
                     <!-- we include our own prototype.js, so don't let stapler pull in another. -->
-                    <st:adjunct assumes="org.kohsuke.stapler.framework.prototype.prototype"
-                                includes="org.kohsuke.stapler.bind"/>
 
                     <script src="${resURL}/scripts/hudson-behavior.js" type="text/javascript"></script>
                     <script src="${resURL}/scripts/sortable.js" type="text/javascript"/>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Removes an unused/broken adjunct that causes a file not found error.

### Testing done

Before:
```
2024-11-19 21:29:56.685+0000 [id=205]   INFO    hudson.lifecycle.Lifecycle#onReady: Jenkins is fully up and running
2024-11-19 21:30:00.435+0000 [id=21]    WARNING o.k.s.f.adjunct.AdjunctsInPage#findNeeded: No such adjunct found: org.kohsuke.stapler.framework.prototype.prototype
org.kohsuke.stapler.framework.adjunct.NoSuchAdjunctException: Neither org.kohsuke.stapler.framework.prototype.prototype.css, .js, .html, nor .jelly were found
        at org.kohsuke.stapler.framework.adjunct.Adjunct.<init>(Adjunct.java:125)
        at org.kohsuke.stapler.framework.adjunct.AdjunctManager.get(AdjunctManager.java:148)
        at org.kohsuke.stapler.framework.adjunct.AdjunctsInPage.findNeeded(AdjunctsInPage.java:161)
        at org.kohsuke.stapler.framework.adjunct.AdjunctsInPage.assumeIncluded(AdjunctsInPage.java:131)
        at org.kohsuke.stapler.framework.adjunct.AdjunctsInPage.assumeIncluded(AdjunctsInPage.java:125)
        at org.kohsuke.stapler.jelly.AdjunctTag.doTag(AdjunctTag.java:80)
        at org.apache.commons.jelly.impl.TagScript.run(TagScript.java:265)
        at org.apache.commons.jelly.impl.ScriptBlock.run(ScriptBlock.java:95)
        at org.kohsuke.stapler.jelly.ReallyStaticTagLibrary$1.run(ReallyStaticTagLibrary.java:101)
        at org.apache.commons.jelly.impl.ScriptBlock.run(ScriptBlock.java:95)
        at org.kohsuke.stapler.jelly.ReallyStaticTagLibrary$1.run(ReallyStaticTagLibrary.java:101)
        at org.apache.commons.jelly.TagSupport.invokeBody(TagSupport.java:161)
        at org.apache.commons.jelly.tags.core.CaseTag.doTag(CaseTag.java:70)
        at org.apache.commons.jelly.impl.TagScript.run(TagScript.java:265)
        at org.apache.commons.jelly.impl.ScriptBlock.run(ScriptBlock.java:95)
        at org.apache.commons.jelly.TagSupport.invokeBody(TagSupport.java:161)
        at org.apache.commons.jelly.tags.core.SwitchTag.doTag(SwitchTag.java:63)
        at org.apache.commons.jelly.impl.TagScript.run(TagScript.java:265)
        at org.apache.commons.jelly.impl.ScriptBlock.run(ScriptBlock.java:95)
        at org.apache.commons.jelly.tags.core.CoreTagLibrary$2.run(CoreTagLibrary.java:105)
        at org.kohsuke.stapler.jelly.JellyViewScript.run(JellyViewScript.java:99)
        at org.kohsuke.stapler.jelly.DefaultScriptInvoker.invokeScript(DefaultScriptInvoker.java:66)
        at org.kohsuke.stapler.jelly.DefaultScriptInvoker.invokeScript(DefaultScriptInvoker.java:55)
        at org.kohsuke.stapler.jelly.ScriptInvoker.execute(ScriptInvoker.java:56)
        at org.kohsuke.stapler.jelly.ScriptInvoker.execute(ScriptInvoker.java:43)
        at org.kohsuke.stapler.Facet.handleIndexRequest(Facet.java:284)
        at org.kohsuke.stapler.jelly.JellyFacet.handleIndexRequest(JellyFacet.java:104)
        at org.kohsuke.stapler.IndexViewDispatcher.dispatch(IndexViewDispatcher.java:32)
        at org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:770)
        at org.kohsuke.stapler.Stapler.invoke(Stapler.java:900)
        at org.kohsuke.stapler.MetaClass$4.doDispatch(MetaClass.java:289)
        at org.kohsuke.stapler.NameBasedDispatcher.dispatch(NameBasedDispatcher.java:59)
        at org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:770)
        at org.kohsuke.stapler.Stapler.invoke(Stapler.java:900)
        at org.kohsuke.stapler.Stapler.invoke(Stapler.java:698)
        at org.kohsuke.stapler.Stapler.service(Stapler.java:248)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:590)
        at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:764)
        at org.eclipse.jetty.servlet.ServletHandler$ChainEnd.doFilter(ServletHandler.java:1665)
        at hudson.util.PluginServletFilter$1.doFilter(PluginServletFilter.java:163)
        at jenkins.util.HttpServletFilter$1.doFilter(HttpServletFilter.java:76)
        at hudson.util.PluginServletFilter$1.doFilter(PluginServletFilter.java:160)
        at hudson.util.PluginServletFilter.doFilter(PluginServletFilter.java:166)
        at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:202)
        at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1635)
        at jenkins.ErrorAttributeFilter.doFilter(ErrorAttributeFilter.java:29)
        at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:202)
        at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1635)
        at hudson.security.csrf.CrumbFilter.doFilter(CrumbFilter.java:160)
        at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:202)
        at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1635)
        at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:94)
        at hudson.security.ChainedServletFilter.doFilter(ChainedServletFilter.java:111)
        at hudson.security.HudsonFilter.doFilter(HudsonFilter.java:172)
        at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:202)
        at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1635)
        at org.kohsuke.stapler.compression.CompressionFilter.doFilter(CompressionFilter.java:53)
        at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:202)
        at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1635)
        at hudson.util.CharacterEncodingFilter.doFilter(CharacterEncodingFilter.java:86)
        at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:202)
        at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1635)
        at org.kohsuke.stapler.DiagnosticThreadNameFilter.doFilter(DiagnosticThreadNameFilter.java:30)
        at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:202)
        at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1635)
        at jenkins.security.SuspiciousRequestFilter.doFilter(SuspiciousRequestFilter.java:38)
        at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:202)
        at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1635)
        at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:527)
        at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:131)
        at org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:569)
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:122)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:223)
        at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:1580)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:221)
        at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1384)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:176)
        at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:484)
        at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1553)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:174)
        at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1306)
        at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:129)
        at org.eclipse.jetty.server.handler.ContextHandlerCollection.handle(ContextHandlerCollection.java:149)
        at org.eclipse.jetty.server.handler.HandlerList.handle(HandlerList.java:51)
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:122)
        at org.eclipse.jetty.server.Server.handle(Server.java:563)
        at org.eclipse.jetty.server.HttpChannel$RequestDispatchable.dispatch(HttpChannel.java:1598)
        at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:753)
        at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:501)
        at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:287)
        at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:314)
        at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:100)
        at org.eclipse.jetty.io.SelectableChannelEndPoint$1.run(SelectableChannelEndPoint.java:53)
        at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.runTask(AdaptiveExecutionStrategy.java:421)
        at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.consumeTask(AdaptiveExecutionStrategy.java:390)
        at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.tryProduce(AdaptiveExecutionStrategy.java:277)
        at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.run(AdaptiveExecutionStrategy.java:199)
        at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:411)
        at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:969)
        at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.doRunJob(QueuedThreadPool.java:1194)
        at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:1149)
        at java.base/java.lang.Thread.run(Thread.java:840)

```

After: No more error

```
2024-11-19 21:30:12.165+0000 [id=269]   INFO    jenkins.InitReactorRunner$1#onAttained: Started initialization
2024-11-19 21:30:12.291+0000 [id=285]   INFO    jenkins.InitReactorRunner$1#onAttained: Listed all plugins
2024-11-19 21:30:14.621+0000 [id=276]   INFO    jenkins.InitReactorRunner$1#onAttained: Prepared all plugins
2024-11-19 21:30:14.632+0000 [id=284]   INFO    jenkins.InitReactorRunner$1#onAttained: Started all plugins
2024-11-19 21:30:14.636+0000 [id=278]   INFO    jenkins.InitReactorRunner$1#onAttained: Augmented all extensions
2024-11-19 21:30:15.057+0000 [id=272]   INFO    jenkins.InitReactorRunner$1#onAttained: System config loaded
2024-11-19 21:30:15.057+0000 [id=272]   INFO    jenkins.InitReactorRunner$1#onAttained: System config adapted
2024-11-19 21:30:15.071+0000 [id=283]   INFO    jenkins.InitReactorRunner$1#onAttained: Loaded all jobs
2024-11-19 21:30:15.087+0000 [id=284]   INFO    jenkins.InitReactorRunner$1#onAttained: Configuration for all jobs updated
2024-11-19 21:30:15.100+0000 [id=284]   INFO    jenkins.model.Jenkins#setInstallState: Install state transitioning from: null to: DEVELOPMENT
2024-11-19 21:30:15.154+0000 [id=275]   INFO    jenkins.InitReactorRunner$1#onAttained: Completed initialization
2024-11-19 21:30:15.222+0000 [id=265]   INFO    hudson.lifecycle.Lifecycle#onReady: Jenkins is fully up and running


```

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
