### PR TITLE
[JENKINS-74085] Extract inline JS scripts in DeliveryPipelineView Fullscreen mode

### DIFF
--- a/src/main/resources/se/diabol/jenkins/pipeline/DeliveryPipelineView/index.jelly
+++ b/src/main/resources/se/diabol/jenkins/pipeline/DeliveryPipelineView/index.jelly
@@ -26,15 +26,16 @@
 
                     <script src="${resURL}/scripts/hudson-behavior.js" type="text/javascript"></script>
                     <script src="${resURL}/scripts/sortable.js" type="text/javascript"/>
-                    <script>
-                        crumb.init("${h.getCrumbRequestField()}", "${h.getCrumb(request)}");
-                    </script>
+                    <span class="fullscreen-data-holder" data-crumb-field="${h.getCrumbRequestField()}"
+                          data-crumb-value="${h.getCrumb(request)}"
+                          data-run-as-test="${h.isUnitTest}"
+                          data-root-url="${rootURL}"
+                          data-res-url="${resURL}" style="display: none"/>
+                    <st:adjunct includes="se.diabol.jenkins.pipeline.DeliveryPipelineView.view-fullscreen"/>
                     <st:adjunct includes="org.kohsuke.stapler.jquery"/>
-                    <script>var Q=jQuery.noConflict()</script>
                     <j:forEach var="pd" items="${h.pageDecorators}">
                         <st:include it="${pd}" page="header.jelly" optional="true" />
                     </j:forEach>
-                    <script>var isRunAsTest=${h.isUnitTest}; var rootURL="${rootURL}"; var resURL="${resURL}";</script>
                 </head>
                 <body>
                 <st:include page="main.jelly"/>

--- a/src/main/resources/se/diabol/jenkins/pipeline/DeliveryPipelineView/view-fullscreen.js
+++ b/src/main/resources/se/diabol/jenkins/pipeline/DeliveryPipelineView/view-fullscreen.js
@@ -15,5 +15,3 @@ document.addEventListener('DOMContentLoaded', function() {
 
     var Q = jQuery.noConflict();
 });
-
-

--- a/src/main/resources/se/diabol/jenkins/pipeline/DeliveryPipelineView/view-fullscreen.js
+++ b/src/main/resources/se/diabol/jenkins/pipeline/DeliveryPipelineView/view-fullscreen.js
@@ -1,5 +1,5 @@
 document.addEventListener('DOMContentLoaded', function() {
-    // Get configuration from data attributes
+
     const configSpan = document.querySelector(".fullscreen-data-holder");
     const crumbRequestField = configSpan.dataset.crumbField;
     const crumbValue = configSpan.dataset.crumbValue;

--- a/src/main/resources/se/diabol/jenkins/pipeline/DeliveryPipelineView/view-fullscreen.js
+++ b/src/main/resources/se/diabol/jenkins/pipeline/DeliveryPipelineView/view-fullscreen.js
@@ -1,0 +1,19 @@
+document.addEventListener('DOMContentLoaded', function() {
+    // Get configuration from data attributes
+    const configSpan = document.querySelector(".fullscreen-data-holder");
+    const crumbRequestField = configSpan.dataset.crumbField;
+    const crumbValue = configSpan.dataset.crumbValue;
+    var isRunAsTest = configSpan.dataset.runAsTest === 'true';
+    var rootURL = configSpan.dataset.rootUrl;
+    var resURL = configSpan.dataset.resUrl;
+
+    window.isRunAsTest = isRunAsTest;
+    window.rootURL = rootURL;
+    window.resURL = resURL;
+
+    crumb.init(crumbRequestField, crumbValue);
+
+    var Q = jQuery.noConflict();
+});
+
+


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

[JENKINS-74085](https://issues.jenkins.io/browse/JENKINS-74085)

Removes inline JS in `DeliveryPipelineView/index.jelly` (fullscreen mode)

Note: 

`var Q = jQuery.noConflict();` Must go inside the event listener for content loaded or it throws a jQuery undefined error. 
### Testing done

[Before showing all breakpoints being triggered](https://www.loom.com/share/25c0d1a2392147dfab0ef501185b4bce)
[After showing same breakpoints being triggered](https://www.loom.com/share/373b5ad122784a40bf55cac7e613ff1f)

To test:
1. Create a new Delivery Pipeline View
2. Save the configuration
3. Select view fullscreen

![Screenshot 2024-11-19 at 5 09 48 PM](https://github.com/user-attachments/assets/0e8982f7-df7c-4ce0-987a-a1b7bb8a89c1)

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
